### PR TITLE
partial pull to update an import style change

### DIFF
--- a/frontend/src/components/StyledComponents/Container.jsx
+++ b/frontend/src/components/StyledComponents/Container.jsx
@@ -5,5 +5,5 @@ export const Container = styled.div`
   flex-direction: column;
   align-items: center;
   background: var(--color-global-tertiary-900);
-  height: 100vh;
+  flex-grow: 1;
 `;

--- a/frontend/src/components/StyledComponents/Main.jsx
+++ b/frontend/src/components/StyledComponents/Main.jsx
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 export const Main = styled.main`
   display: flex;
   flex-direction: row;
-  wrap: no-wrap;
+  flex-grow: 1;
   width: 100%;
+  wrap: no-wrap;
   padding: 20px;
-  height: 100%;
 `;

--- a/frontend/src/pages/About/About.jsx
+++ b/frontend/src/pages/About/About.jsx
@@ -30,7 +30,12 @@ const About = () => {
     ).then( data => setDevs(data));
   },[])
 
-  if (devs.length <= 0) return <Loading />;
+  if (devs.length <= 0) return (
+      <div>
+        <p>Either loading resources from GitHub or your internet connect is offline.</p>
+        <Loading />
+      </div>
+    );
 
   if (rateLimited) return (
     <div>

--- a/frontend/src/pages/Admin/Admin.jsx
+++ b/frontend/src/pages/Admin/Admin.jsx
@@ -2,13 +2,13 @@ import React, {useContext} from 'react';
 import { SchedulerContext } from '../../SchedulerContext';
 import { RuxButton } from '../../../node_modules/@astrouxds/react/dist/components';
 import {AdminContainer, Padding, VerticalSpacer} from './AdminStyles';
+import Loading from '../../components/Loading/Loading';
 
 const Admin = () => {
 
     const scheduler = useContext(SchedulerContext);
 
     console.log(scheduler);
-
 
     const handleDataUpload = () => {
         alert('This button uploads a new schedule');
@@ -37,7 +37,7 @@ const Admin = () => {
                     </Padding>
                 </div>
                 <div>
-                   <p>Calendar Here</p> 
+                   { (scheduler.roster.length === 0) ? <Loading /> : <p>Calendar Here</p> } 
                 </div>
             </VerticalSpacer>
 

--- a/frontend/src/pages/Admin/Admin.jsx
+++ b/frontend/src/pages/Admin/Admin.jsx
@@ -3,6 +3,7 @@ import { SchedulerContext } from '../../SchedulerContext';
 import { RuxButton } from '../../../node_modules/@astrouxds/react/dist/components';
 import {AdminContainer, Padding, VerticalSpacer} from './AdminStyles';
 import Loading from '../../components/Loading/Loading';
+import Calendar from '../Calendar/Calendar';
 
 const Admin = () => {
 
@@ -37,7 +38,7 @@ const Admin = () => {
                     </Padding>
                 </div>
                 <div>
-                   { (scheduler.roster.length === 0) ? <Loading /> : <p>Calendar Here</p> } 
+                   { (scheduler.roster.length === 0) ? <Loading /> : <Calendar /> } 
                 </div>
             </VerticalSpacer>
 


### PR DESCRIPTION
this includes a fix to the black background which didn't scale with the other components making it look like calendars and rosters were running off screen, even with a scroll bar.

Also patched admin to include the calendar component OR loading based on Context.

Also fixes a bug in About in which the server is running but there is no Internet connection, so displays a helpful message for why the content is Loading.

NOTICED A BUG: the calendar component contains a Download button, so it gets imported into Admin, duplicating the efforts of Export Data.