### PR TITLE
Two fixes (style and bug)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,6 @@
 //@ts-check
 
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Routes, Route, useLocation, Link, NavLink } from 'react-router-dom';
 import './App.css';
 import Header from './components/Header/Header';
@@ -19,6 +19,7 @@ import { Center } from './components/StyledComponents/Center';
 import { Right } from './components/StyledComponents/Right';
 
 const App = () => {
+  const [everGrowingRosterSize, setEverGrowingRosterSize] = useState(0);
   const { data: rosterData, err: rosterErr, load: rosterLoad } = useFetch('roster');
   // TODO: Replace with a real fetch request
   const { data: calendarData, err: calendarErr, load: calendarLoad } = useFetch('calendar?start=1&end=31');
@@ -26,6 +27,7 @@ const App = () => {
 
   useEffect(() => {
     scheduler.roster = rosterData;
+    setEverGrowingRosterSize(rosterData.length);
   }, [rosterData]);
 
   useEffect(() => {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,6 @@
 //@ts-check
 
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { Routes, Route, useLocation, Link, NavLink } from 'react-router-dom';
 import './App.css';
 import Header from './components/Header/Header';
@@ -19,7 +19,6 @@ import { Center } from './components/StyledComponents/Center';
 import { Right } from './components/StyledComponents/Right';
 
 const App = () => {
-  const [everGrowingRosterSize, setEverGrowingRosterSize] = useState(0);
   const { data: rosterData, err: rosterErr, load: rosterLoad } = useFetch('roster');
   // TODO: Replace with a real fetch request
   const { data: calendarData, err: calendarErr, load: calendarLoad } = useFetch('calendar?start=1&end=31');
@@ -27,7 +26,7 @@ const App = () => {
 
   useEffect(() => {
     scheduler.roster = rosterData;
-    setEverGrowingRosterSize(rosterData.length);
+    scheduler.counter = rosterData.length;
   }, [rosterData]);
 
   useEffect(() => {

--- a/frontend/src/SchedulerContext.jsx
+++ b/frontend/src/SchedulerContext.jsx
@@ -3,4 +3,5 @@ import React from 'react';
 export const SchedulerContext = React.createContext({
   roster: [],
   calendar: [],
+  counter: 0,
 });

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -10,7 +10,7 @@ import { SchedulerContext } from './SchedulerContext';
 ReactDOM.render(
   <React.StrictMode>
     <Router>
-      <SchedulerContext.Provider value={{roster: {}, calendar: {}}}>
+      <SchedulerContext.Provider value={{roster: {}, calendar: {}, counter: 0}}>
        <App />
       </SchedulerContext.Provider>
     </Router>

--- a/frontend/src/pages/Admin/AdminAddNewUser/AdminAddNewUser.jsx
+++ b/frontend/src/pages/Admin/AdminAddNewUser/AdminAddNewUser.jsx
@@ -20,7 +20,9 @@ const AdminAddNewUser = ({setStatus: updateScreen}) => {
     const navigate = useNavigate();
 
     const handleSave = () => {
-        const newId = scheduler.roster.length + 1;
+        scheduler.counter++;
+        const newId = scheduler.counter;
+        scheduler.counter++;
         const newMember = {
             "id": newId,
             "first": firstName,

--- a/frontend/src/pages/Calendar/Calendar.jsx
+++ b/frontend/src/pages/Calendar/Calendar.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import Loading from '../../components/Loading/Loading';
 import { Link, useLocation } from 'react-router-dom';
+import { RuxButton } from '../../../node_modules/@astrouxds/react/dist/components';
 import { CalendarMonthlyLayout } from '../../components/StyledComponents/CalendarMonthlyLayout';
 import { CalendarDayCard } from '../../components/StyledComponents/CalendaryDayCard';
 import { ShiftContainer } from '../../components/StyledComponents/ShiftContainer';
@@ -55,12 +56,12 @@ const Calendar = () => {
   return (
     <article style={{ width: '100%' }}>
         {location === '/' && 
-              <button
+              <RuxButton
               style={{ padding: '1rem' }}
               onClick={() => saveCsv(data, `Schedule_${new Date().getUTCFullYear()}_${new Date().getUTCMonth() + 1}`)}
             >
               Download
-            </button>
+            </RuxButton>
         }
       <br />
       <br />


### PR DESCRIPTION
Fixes the styling on the Download button of Calendar

Fixes the bug I mentioned in my commit yesterday about collisions of member ids when removing members and then adding members... resulting in the re-using of the old member ids. Added a counter to context object which acts as a sort of Primary Key that auto-increments as new Members are added preventing new members from colliding with removed members.